### PR TITLE
Style the playlist tracks display page

### DIFF
--- a/frontend/src/components/SharedPlaylistDisplay.jsx
+++ b/frontend/src/components/SharedPlaylistDisplay.jsx
@@ -12,41 +12,55 @@ const SharedPlaylistDisplay = ({ playlistData }) => {
   }
 
   return (
-    <div className="playlist-info">
+    <div className=" mx-10">
       <div className="playlists">
-        <h2>{playlistData.name}</h2>
+        <h2 className="text-2xl md:text-4xl mx-1 my-5 md:my-8 md:mx-6">
+          {playlistData.name}
+        </h2>
 
-        <p>Total Tracks: {playlistData.tracks.total}</p>
-        <img
-          src={
-            playlistData.images.length > 0
-              ? playlistData.images[0].url
-              : "https://res.cloudinary.com/teepublic/image/private/s--n4uagiOn--/c_crop,x_10,y_10/c_fit,h_799/c_crop,g_north_west,h_1051,w_1051,x_-171,y_-121/l_upload:v1507037314:production:blanks:gbajnunp66ec7xftnpq1/fl_layer_apply,g_north_west,x_-276,y_-220/b_rgb:ffffff/c_limit,f_jpg,h_630,q_90,w_630/v1539384919/production/designs/3309274_0.jpg"
-          }
-          alt=""
-          style={{ width: "480px", height: "200px" }}
-        />
+        <p className="text-xl md:text-2xl mx-1 my-2 md:my-2 md:mx-6">
+          Total Tracks: {playlistData.tracks.total}
+        </p>
+        <div className="h-72 md:w-96 md:h-96">
+          <img
+            src={
+              playlistData.images.length > 0
+                ? playlistData.images[0].url
+                : "https://res.cloudinary.com/teepublic/image/private/s--n4uagiOn--/c_crop,x_10,y_10/c_fit,h_799/c_crop,g_north_west,h_1051,w_1051,x_-171,y_-121/l_upload:v1507037314:production:blanks:gbajnunp66ec7xftnpq1/fl_layer_apply,g_north_west,x_-276,y_-220/b_rgb:ffffff/c_limit,f_jpg,h_630,q_90,w_630/v1539384919/production/designs/3309274_0.jpg"
+            }
+            alt=""
+          />
+        </div>
       </div>
-      <p>
-        <strong>Tracks:</strong>
-      </p>
-      {playlistData.tracks.items.map((track, trackIndex) => (
-        <div key={trackIndex}>
-          <p>
-            <strong>Track Name:</strong>
-            {track.track.name}
-          </p>
 
-          <p>
-            <strong>length:</strong> {formatDuration(track.track.duration_ms)}
-          </p>
+      {playlistData.tracks.items.map((track, trackIndex) => (
+        <div
+          className="grid grid-cols-2 
+        mt-8
+        gap-3
+        md:grid-cols-3
+        lg:grid-cols-5
+        md:gap-5
+        text-xl
+        md:text-3xl
+        md:mx-6"
+        >
           {track.track.album.images.length > 0 && (
             <img
               src={track.track.album.images[0].url}
               alt={`Album Cover for ${track.track.name}`}
-              style={{ width: "100px", height: "100px" }}
+              
             />
           )}
+          <div className="grid grid-rows">
+            <p>
+              <strong>Track Name: </strong>
+              {track.track.name}
+            </p>
+            <p>
+              <strong>Length:</strong> {formatDuration(track.track.duration_ms)}
+            </p>
+          </div>
         </div>
       ))}
     </div>

--- a/frontend/src/components/dialogs/PlaylistTracksFilterModal.jsx
+++ b/frontend/src/components/dialogs/PlaylistTracksFilterModal.jsx
@@ -1,6 +1,7 @@
 import { Dialog } from "@headlessui/react";
+import GenreFilter from "../DynamicGenres";
 
-function PlaylistTracksFilterModal({ isOpen, handleModalOpen }) {
+function PlaylistTracksFilterModal({ isOpen, handleModalOpen, playlistData }) {
 
   return (
     <Dialog
@@ -14,6 +15,8 @@ function PlaylistTracksFilterModal({ isOpen, handleModalOpen }) {
           <Dialog.Description className="text-lg">Genre</Dialog.Description>
 
           <p>Filter by genre</p>
+
+          <GenreFilter playlistData={playlistData} />
         </div>
 
         <div className="m-3 text-lg">

--- a/frontend/src/components/screens/PlaylistTracksScreen.jsx
+++ b/frontend/src/components/screens/PlaylistTracksScreen.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import GenreFilter from "../DynamicGenres";
 import SharedPlaylistDisplay from "../SharedPlaylistDisplay";
 import Header from "../Header"
 import PlaylistTracksFilterModal from "../dialogs/PlaylistTracksFilterModal";
@@ -57,19 +56,19 @@ useEffect(() => {
     
   return (
     <div className="text-white bg-black grow">
-      <Header/>
-      {/* <h2>PlaylistTracksScreen</h2> */}
+      <Header />
       <button
-        className="ml-3 inline-flex justify-center rounded-md border-2 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 sm:ml-3 sm:w-auto"
+        className=" ml-60 inline-flex justify-center rounded-md border-2 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 sm:ml-3 sm:w-auto"
         onClick={() => handleModalOpen(true)}
       >
         Filter by
       </button>
       <PlaylistTracksFilterModal
+        playlistData={playlistData}
         isOpen={isOpen}
         handleModalOpen={handleModalOpen}
       />
-      <GenreFilter playlistData={playlistData} />
+
       <SharedPlaylistDisplay playlistData={playlistData} />
     </div>
   );


### PR DESCRIPTION
* Make it similar to the latest design
* Display the tracks in grid similar to the latest design in mobile version
* Put the genre filter inside the modal
* Just do a basic mobile version according to the design so that people can demo during presentation because it's very late :)

This is how it looks now:

![image](https://github.com/Afsha10/song-sieve/assets/115444059/31a4dab3-cfa7-42bd-b0ad-86704f017033)
