### PR TITLE
Fix failed token request

### DIFF
--- a/frontend/src/components/screens/LoginScreen.jsx
+++ b/frontend/src/components/screens/LoginScreen.jsx
@@ -4,10 +4,11 @@ import { sha256 } from "../../utils/encodingUtils";
 import { base64encode } from "../../utils/encodingUtils";
 import { redirectToSpotify } from "../../utils/spotifyApiUtils";
 import HeaderLogin from "../HeaderLogin";
+import { config } from "../../config";
 //import bg from "../images/hero.jpg";
-// import "dotenv/config";
 
 function LoginScreen() {
+  console.log("redirectUri", config.redirectUri);
   useEffect(() => {
     async function codeChallengeReturn() {
       const codeVerifier = generateRandomString(64);
@@ -26,43 +27,43 @@ function LoginScreen() {
 
   return (
     <div>
-      <HeaderLogin/>
-    <div style={{display:"flex",justifyContent:"center"}}>
-      
-    <div className="mainLoginDiv">
-            <div className="firstLoginDiv">
-                 
-                  <p id="textLogin">
-                    Hello sunshine !! This app will help you to bring a playlist and create
-                    your own playlist with the tracks you love. Sign up to save your
-                    playlist, then upload your customised playlist to your Spotify account.
-                  </p>
-                  <div className="divLoginBtn">
-                    <div>
-                        <button
-                          onClick={() => {
-                            // taking the current page URL and adding app route to it
-                              const redirectURI = window.location.href + "app"
-                              redirectToSpotify(
-                                localStorage.getItem("codeVerifier"),
-                                localStorage.getItem("codeChallenge"),
-                                "user-read-private playlist-read-private user-read-email",
-                                redirectURI
-                              )
-                            }
-                          }
-                        >
-                          Sign in
-                        </button>
-                      </div>
-                  </div>
+      <HeaderLogin />
+      <div style={{ display: "flex", justifyContent: "center" }}>
+        <div className="mainLoginDiv">
+          <div className="firstLoginDiv">
+            <p id="textLogin">
+              Hello sunshine !! This app will help you to bring a playlist and
+              create your own playlist with the tracks you love. Sign up to save
+              your playlist, then upload your customised playlist to your
+              Spotify account.
+            </p>
+            <div className="divLoginBtn">
+              <div>
+                <button
+                  onClick={() => {
+                    // taking the current page URL and adding app route to it
+                    const redirectUri = window.location.href + "app";
+                    redirectToSpotify(
+                      localStorage.getItem("codeVerifier"),
+                      localStorage.getItem("codeChallenge"),
+                      "user-read-private playlist-read-private user-read-email",
+                      redirectUri
+                    );
+                  }}
+                >
+                  Sign in
+                </button>
+              </div>
             </div>
-            <div className="secondLoginDiv" >
-                    <img src="https://cdn2.psychologytoday.com/assets/styles/manual_crop_1_91_1_1528x800/public/blogs/30322/2009/07/31495-12668.jpg?itok=31b-A7bj" alt=""/>
-            </div>
-        
-    </div>
-    </div> 
+          </div>
+          <div className="secondLoginDiv">
+            <img
+              src="https://cdn2.psychologytoday.com/assets/styles/manual_crop_1_91_1_1528x800/public/blogs/30322/2009/07/31495-12668.jpg?itok=31b-A7bj"
+              alt=""
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/screens/MainScreen.jsx
+++ b/frontend/src/components/screens/MainScreen.jsx
@@ -2,15 +2,16 @@ import React, { useState, useEffect } from "react";
 import SharePlaylistInputBox from "../SharePlaylistInputBox";
 import Header from "../Header";
 import Playlists from "../Playlists";
-
-
+import { config } from "../../config";
 
 const clientId = "719d232ba04d433d98b3605bf4b316e1";
-const redirectUri = "http://localhost:3000/app";
+const redirectUri = config.redirectUri;
+
 const url = "https://accounts.spotify.com/api/token";
 
 function MainScreen() {
   const [accessToken, setAccessToken] = useState(null);
+  console.log("redirect Uri", redirectUri);
 
   useEffect(() => {
     function getToken() {
@@ -54,8 +55,6 @@ function MainScreen() {
       </div>
       <SharePlaylistInputBox />
       {accessToken && <Playlists />}
-      
-      
     </div>
   );
 }

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,9 @@
+const prod = {
+  redirectUri: "https://song-sieve-frontend.onrender.com/app",
+};
+const dev = {
+  redirectUri: "http://localhost:3000/app",
+};
+
+export const config = process.env.NODE_ENV === "development" ? dev : prod;
+


### PR DESCRIPTION
* This fixes a bug where we have hardcoded the redirect URI into the payload which is sent to Spotify when exchanging the code for an access token. Unless the computer has the app running locally on port 3000, they will not be able to access the token correctly. The change I made allows for the use of redirect URIs for both production and development deployments. This makes the code more flexible and easier to work with.