### PR TITLE
Connect playlist items to playlist tracks page

### DIFF
--- a/frontend/src/components/Playlists.jsx
+++ b/frontend/src/components/Playlists.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
-
 import playlistPlaceholderImage from "./images/music-notes.svg";
+import { Link } from "react-router-dom";
 
 
 function Playlists({playlists}) {
@@ -20,12 +19,14 @@ function Playlists({playlists}) {
       </p>
       <div className="grid grid-cols-2 gap-10 m-8 md:grid-cols-3 lg:grid-cols-5 md:gap-10 text-xl md:text-3xl md:mx-6">
         {playlists !== null &&
-         playlists.items !== undefined &&
+          playlists.items !== undefined &&
           playlists.items.map((playlist, index) => (
             <div key={index}>
-              <div className="2">{modifyImageUrl(playlist)}</div>
-              <p>{playlist.name}</p>
-              <p className=" text-gray-400">{playlist.tracks.total} tracks</p>
+              <Link to={`/app/playlist/${playlist.id}`}>
+                <div>{modifyImageUrl(playlist)}</div>
+                <p>{playlist.name}</p>
+                <p className="text-gray-400">{playlist.tracks.total} tracks</p>
+              </Link>
             </div>
           ))}
       </div>


### PR DESCRIPTION
* Add link to playlist items so that each of the playlists takes us to it's tracks page
* Remove className="2" because it is a strange name for class and it does not really add any value as we are already using tailwind for styling

Here is a video for you to see how it is working now:

[Screencast from 28-11-23 00:27:05.webm](https://github.com/Afsha10/song-sieve/assets/115444059/8a3be607-0da8-40da-b260-49635618cd04)
