### PR TITLE
Style the tracks page for displaying on tablet and desktop

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -35,14 +35,10 @@ import { Link } from 'react-router-dom'
           </div>
 
           <div>
-            <p>
-              Spotify Playlist Sieve
-            </p>
+            <p>Spotify Playlist Sieve</p>
           </div>
-          <div>
-            <p>
-              Hello {userName}
-            </p>
+          <div className="header_username">
+            <p>Hello {userName}!</p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/SharedPlaylistDisplay.jsx
+++ b/frontend/src/components/SharedPlaylistDisplay.jsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-
-
 function formatDuration(durationInMilliseconds) {
   const minutes = Math.floor(durationInMilliseconds / 60000);
   const seconds = ((durationInMilliseconds % 60000) / 1000).toFixed(0);
@@ -18,16 +16,16 @@ const SharedPlaylistDisplay = ({ playlistData,filterExplicit }) => {
 
   
   return (
-    <div className=" mx-10">
-      <div className="playlists">
-        <h2 className="text-2xl md:text-4xl mx-1 my-5 md:my-8 md:mx-6">
+    <div className="mx-10">
+      <div>
+        <p className="text-2xl text-center md:text-4xl mx-1 my-1 md:my-2">
           {playlistData.name}
-        </h2>
-
-        <p className="text-xl md:text-2xl mx-1 my-2 md:my-2 md:mx-6">
-          Total Tracks: {playlistData.tracks.total}
         </p>
-        <div className="h-72 md:w-96 md:h-96 m-4">
+
+        <p className="text-xl text-center md:text-3xl mx-1 my-2 md:my-6 text-gray-400">
+          {playlistData.tracks.total} tracks
+        </p>
+        <div className=" w-72 md:w-80 mx-auto">
           <img
             src={
               playlistData.images.length > 0
@@ -37,40 +35,38 @@ const SharedPlaylistDisplay = ({ playlistData,filterExplicit }) => {
             alt=""
           />
         </div>
-        
       </div>
-
-      {filteredTracks.map((track, trackIndex) => (
-        <div
-          className="grid grid-cols-2 
-        mt-8
-        mx-4
-        gap-3
-        md:grid-cols-3
-        lg:grid-cols-5
+      <div className="grid grid-cols-1 gap-10 my-14 md:grid-cols-2 lg:grid-cols-4 md:gap-10 text-xl md:text-3xl md:mx-6">
+        {playlistData.tracks.items.map((track, trackIndex) => (
+          <div
+            className="grid grid-cols-2 
         md:gap-5
         text-xl
-        md:text-3xl
-        md:mx-6"
-        >
-          {track.track.album.images.length > 0 && (
-            <img
-              src={track.track.album.images[0].url}
-              alt={`Album Cover for ${track.track.name}`}
-            />
-          )}
-          <div className="grid grid-rows">
-            <p>
-              <strong>Track Name: </strong>
-              {track.track.name}
-            </p>
-            <p className=" text-gray-400">
-              <strong>Length:</strong> {formatDuration(track.track.duration_ms)}
-            </p>
+        md:text-3xl"
+          >
+            {track.track.album.images.length > 0 && (
+              <img
+                src={track.track.album.images[0].url}
+                alt={`Album Cover for ${track.track.name}`}
+              />
+            )}
+            <div className="flex-col m-2">
+              <p className="font-bold text-blue-400">{track.track.name}</p>
+              <p className=" text-gray-400">
+                {formatDuration(track.track.duration_ms)}
+              </p>
+              <button className="m-2 rounded bg-brown-300 px-4 py-2 font-bold text-red-900 transition-colors duration-200 hover:bg-red-100 active:bg-red-500 sm:rounded-lg sm:px-2 sm:py-2">
+                Remove
+              </button>
+            </div>
           </div>
-        </div>
-      ))}
-      
+        ))}
+      </div>
+      <div className="flex justify-center">
+        <button className="mt-0 mb-10 rounded bg-blue-100 px-4 py-2 font-bold text-blue-700 sm:text-xl lg:text-3xl transition-colors duration-200 hover:bg-blue-300 active:bg-blue-500 sm:rounded-lg sm:px-12 sm:py-6">
+          Save playlist
+        </button>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/screens/PlaylistTracksScreen.jsx
+++ b/frontend/src/components/screens/PlaylistTracksScreen.jsx
@@ -56,12 +56,15 @@ useEffect(() => {
   return (
     <div className="text-white bg-black grow">
       <Header />
-      <button
-        className=" ml-56 mx-4 inline-flex justify-center rounded-md border-2 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 sm:ml-3 sm:w-auto"
-        onClick={() => handleModalOpen(true)}
-      >
-        Filter by
-      </button>
+      <div className="flex justify-end mx-8">
+        <button
+          className="m-1 rounded border-8 border-blue-600 px-3 py-2 text-sm md:text-xl font-bold text-white transition-colors duration-300  hover:bg-blue-700 sm:ml-3 sm:w-auto md:p-4 md:mx-8"
+          onClick={() => handleModalOpen(true)}
+        >
+          Filter by
+        </button>
+      </div>
+
       <PlaylistTracksFilterModal
         playlistData={playlistData}
         isOpen={isOpen}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -99,6 +99,9 @@ margin: 10px 15px;
     color: white;
     margin-top: 3px;
   }
+  .header_username p{
+    color: #55b2eb;
+  }
   .firstLoginDiv p{
     color: white;
     text-align: left;


### PR DESCRIPTION
Changes made to Header

* Have a different colour for the greeting and username from the app name to distinguish the app name from the greeting the user

Changes made to PlaylistTracksScreen

* Make the filter button stand out by creating a blue border around it
* Make the "Filter by" button to the right of the page as in the updated design

Changes made to SharedPlaylistDisplay:

* Make the playlist image centred in the tracks page so that it is clear to the users that it is different from the tracks images
* Changed the text under playlist name 100 tracks instead of Total tracks: 100 as the first options sounds less technical
* Change the h2 tag to p tag as there is not h1 tag in this repo. Thus, it is more semantically correct
* Remove "Track name" and "Length" for displaying every track name and their length, rather just have the track names displayed as it seems self explanatory
* Make a two column grid to display the tracks on tablet and a four column grid to display the track on desktop
* Change the tracks name to blue colour to make them not blend with them different from the playlist name
* Add remove button to remove unwanted tracks from the tracks list
* Add a save button to save the edited playlist

Mobile version before:
![Screenshot from 2023-11-28 16-42-46](https://github.com/Afsha10/song-sieve/assets/115444059/95238b8c-f6e3-4b2d-8f26-8060ccfdd0cb)

Mobile version after the above changes:
![image](https://github.com/Afsha10/song-sieve/assets/115444059/d8d981b2-6d6a-4e90-aaf2-87bc20feb554)
![image](https://github.com/Afsha10/song-sieve/assets/115444059/f314b973-62a8-4436-9afb-74a98fccb1b1)

Tablet version before:
![Screenshot from 2023-11-28 16-41-29](https://github.com/Afsha10/song-sieve/assets/115444059/38a252f8-5f52-41b5-a0bb-34ed8a7a1181)

Tablet version after the above changes:
![image](https://github.com/Afsha10/song-sieve/assets/115444059/9445999d-1827-4c14-bf3f-b9ad11ff0e8d)
![image](https://github.com/Afsha10/song-sieve/assets/115444059/2707585c-d571-4875-afeb-c1db728b0239)

Desktop version before:
![Screenshot from 2023-11-28 16-32-07](https://github.com/Afsha10/song-sieve/assets/115444059/ff777961-116a-4a1a-a571-4d24bacf84a3)

Desktop version after the above changes:
![image](https://github.com/Afsha10/song-sieve/assets/115444059/2cfb9679-debe-4611-a182-1883daf15203)
![image](https://github.com/Afsha10/song-sieve/assets/115444059/32e5d149-d74b-4b7d-bc4d-64c81965b202)



