### PR TITLE
Position the iframe player above the track that is clicked

### DIFF
--- a/frontend/src/components/SharedPlaylistDisplay.jsx
+++ b/frontend/src/components/SharedPlaylistDisplay.jsx
@@ -7,7 +7,6 @@ function formatDuration(durationInMilliseconds) {
 }
 
 const SharedPlaylistDisplay = ({ playlistData }) => {
-  const [playTracks, setPlayTracks] = useState(false);
   const [uri, setUri] = useState("");
   const [urlTrack, setUrlTrack] = useState();
 
@@ -32,10 +31,9 @@ const SharedPlaylistDisplay = ({ playlistData }) => {
     setUri(spotifyUri);
     setUrlTrack(spotifyUrl);
     console.log(urlTrack);
-    setPlayTracks(true);
   };
 
-  if (!playlistData || !playlistData.tracks) {
+  if (!playlistData?.tracks) {
     return <div>Loading...</div>; // You can replace this with your loading indicator or message
   }
 
@@ -63,37 +61,22 @@ const SharedPlaylistDisplay = ({ playlistData }) => {
         </div>
       </div>
       <div className="grid grid-cols-1 gap-10 my-14 md:grid-cols-2 lg:grid-cols-4 md:gap-10 text-xl md:text-3xl md:mx-6">
-        {playTracks && (
-          <div id="embed-iframe">
-            <iframe
-              src={`https://open.spotify.com/embed/track/${urlTrack}`}
-              width="280"
-              height="100"
-            ></iframe>
-            <button
-              style={{ position: "relative" }}
-              onClick={() => setPlayTracks(false)}
-            >
-              ❌
-            </button>
-          </div>
-        )}
         {playlistData.tracks.items.map((track, trackIndex) => (
           <div
             key={trackIndex}
             className="grid grid-cols-2 
-        md:gap-5
-        text-xl
-        md:text-3xl"
+              md:gap-5
+              text-xl
+              md:text-3xl"
           >
             {track.track.album.images.length > 0 && (
-                <img
-                  key={trackIndex}
-                  src={track.track.album.images[0].url}
-                  alt={`Album Cover for ${track.track.name}`}
-                  style={{ cursor: "pointer" }}
-                  onClick={() => handlePlay(track.track.uri, track.track.id)}
-                />
+              <img
+                key={trackIndex}
+                src={track.track.album.images[0].url}
+                alt={`Album Cover for ${track.track.name}`}
+                style={{ cursor: "pointer" }}
+                onClick={() => handlePlay(track.track.uri, track.track.id)}
+              />
             )}
             <div className="ml-6 sm:m-0 flex-rows">
               <p className=" font-medium text-blue-400">{track.track.name}</p>
@@ -101,6 +84,21 @@ const SharedPlaylistDisplay = ({ playlistData }) => {
                 {formatDuration(track.track.duration_ms)}
               </p>
             </div>
+            {track.track.id === urlTrack && (
+              <div className="absolute z-10 visible p-4 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm opacity-100 tooltip dark:bg-gray-300" role="tooltip"id="embed-iframe">
+                <iframe
+                  src={`https://open.spotify.com/embed/track/${urlTrack}`}
+                  width="280"
+                  height="80"
+                  title="music player"
+                ></iframe>
+                <button className="ml-2"
+                  onClick={() => setUrlTrack(null)}
+                >
+                  ❌
+                </button>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,6 +1,6 @@
-//export const redirectUri = "https://song-sieve-frontend.onrender.com/app"; // production
+export const redirectUri = "https://song-sieve-frontend.onrender.com/app"; // production
 
- export const redirectUri = "http://localhost:3000/app"; // development
+//  export const redirectUri = "http://localhost:3000/app"; // development
 
 
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -176,9 +176,9 @@ code {
 }
 #embed-iframe {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
 }
 @media (min-width: 600px) {
   .mainLoginDiv {


### PR DESCRIPTION
* Add a title for iframe for the screen readers to understand what is happening
* Replace (!playlistData || !playlistData.track) with (!playlistData?.tracks) as they mean the same thing but the second one is shorter
* Move the player within the tracks div where all the info about each track is displayed and only show the iframe only when the track ID that is clicked matches the urlTrack
* Make it position absolute so that it can be on top of the tracks image
* Remove playTracks useState and remove setPlayTracks in handlePlay because we don't need them at all
* Inside the onClick in iframe, call setUrlTrack to null
* Make some styling changes using CSS and Tailwind to style the iframe and put the cross symbol to close the iframe at the top right corner

Iframe position before changes:

![image](https://github.com/Afsha10/song-sieve/assets/115444059/f32f8f89-1dd8-47b6-b628-76dae399a669)

Ifram position after changes: 

![image](https://github.com/Afsha10/song-sieve/assets/115444059/100fc239-eacc-4755-af03-a3c49b7e0f3c)
