### PR TITLE
Make the clean button reset the filter values and store the radio but…

### DIFF
--- a/frontend/src/components/dialogs/PlaylistTracksFilterModal.jsx
+++ b/frontend/src/components/dialogs/PlaylistTracksFilterModal.jsx
@@ -9,6 +9,7 @@ function PlaylistTracksFilterModal({
   setFilteredPlaylistData,
 }) {
   const [range, setRange] = useState(20);
+  const [isExplicit, setIsExplicit] = useState(false)
 
   return (
     <Dialog
@@ -26,8 +27,8 @@ function PlaylistTracksFilterModal({
             console.log("form data get", formData.get("isExplicit"));
             console.log("duration", formData.get("duration"));
             console.log("genre", formData.get("selectedGenre"));
-            const isExplicit = formData.get("isExplicit") === "true"
-            const duration = Number(formData.get("duration"))
+            const isExplicit = formData.get("isExplicit") === "true";
+            const duration = Number(formData.get("duration"));
 
             // playlistData.tracks.items[0].track.explicit;
             const filteredItems = playlistData.tracks.items.filter((item) => {
@@ -79,6 +80,8 @@ function PlaylistTracksFilterModal({
               id="isExplicitTrue"
               name="isExplicit"
               value="true"
+              checked={isExplicit}
+              onChange={() => setIsExplicit(true)}
             />
             <label htmlFor="isExplicitTrue">Yes</label>
 
@@ -87,6 +90,8 @@ function PlaylistTracksFilterModal({
               id="isExplicitFalse"
               name="isExplicit"
               value="false"
+              checked={!isExplicit}
+              onChange={() => setIsExplicit(false)}
             />
             <label htmlFor="isExplicitFalse">No</label>
             {/* <ContentCheckbox playlistData={playlistData} /> */}
@@ -95,7 +100,12 @@ function PlaylistTracksFilterModal({
           <div className="flex flex-row justify-center m-auto my-4">
             <button
               className="ml-3 inline-flex justify-center rounded-md border-2 px-3 py-2 text-sm font-semibold text-black shadow-sm hover:bg-blue-700 sm:ml-3 sm:w-auto"
-              onClick={() => handleModalOpen(false)}
+              onClick={(e) => {
+                e.preventDefault();
+                setRange(20);
+                setFilteredPlaylistData(playlistData);
+                setIsExplicit(false)
+              }}
             >
               Clean
             </button>


### PR DESCRIPTION
…ton selection

* Make the clean button reset the filter values by using the setter functions to initial state on the onClick handler function
* Use a controlled component for handling the filter data (the state is outside of the form and so it will persist when we close and reopen the modal)
* On the form, when we submit it, the data goes apart form it being available on the onSubmit handler  gets submitted, it gets sent using formData
* To prevent onSubmit from being called, do event.preventDefault() in the clean onClick handler and pass in event as a parameter

Testing below (it is working): 

[Screencast from 04-12-23 23:55:11.webm](https://github.com/Afsha10/song-sieve/assets/115444059/84b3ecc5-32ef-44db-9f52-b115deaa3d4f)

It's working!